### PR TITLE
docs: sync zh/es/pt READMEs with English source

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -165,6 +165,36 @@ Cada mensaje de usuario recién confirmado (y cada carga de fragmento) registra 
 
 `Ctrl+R` marca los resúmenes `[compacted] …` con una insignia ámbar (el historial permanece sin insignia), los fragmentos en verde, las plantillas en morado — la procedencia del panel es visible de un vistazo. Se alterna con `enableCompactionHighlight`.
 
+## Exportación e importación de respaldo
+
+Las cuatro bibliotecas locales del navegador exportan e importan desde un único documento JSON versionado. Las acciones **Export JSON / Copy JSON / Import file / Paste JSON** del panel se ejecutan completamente en el navegador: descarga o copia al portapapeles al exportar, selector de archivo o texto pegado al importar — nada se sube y no hay RPC de host ni llamadas de red.
+
+**Forma del documento**
+
+```json
+{
+  "schemaVersion": 1,
+  "exportedAt": 1735689600000,
+  "data": {
+    "history": ["…"],
+    "snippets": [{ "name": "…", "text": "…", "tags": [], "scope": "global", "createdAt": 0, "updatedAt": 0, "useCount": 0, "lastUsedAt": 0 }],
+    "templates": [{ "name": "…", "text": "…", "description": "", "updatedAt": 0 }],
+    "insights": [{ "text": "…", "sessions": [], "uses": 0, "lastUsedAt": 0 }]
+  }
+}
+```
+
+**Estrategia de fusión y conflictos**
+
+- Las entradas de historial son cadenas planas y se deduplican por texto exacto; una entrada duplicada o vacía se omite, nunca se sobrescribe.
+- Los snippets y plantillas se indexan por `name`; los insights por `text` exacto. En un conflicto de misma clave gana la **marca de tiempo más nueva** (`updatedAt` para snippets/plantillas, `lastUsedAt` para insights); una importación más antigua o de igual marca se omite, y las claves nuevas se añaden.
+- La importación respeta `maxPersisted` y `maxSnippets`; las plantillas e insights se limitan a sus topes de protocolo (`500` cada uno).
+- El aviso de resultado informa cuántos registros se escribieron y cuántos se omitieron (antiguos/duplicados).
+
+**Versionado de esquema**
+
+`schemaVersion` empieza en `1`. Las importaciones ejecutan una migración por pasos (una versión a la vez) para que los formatos futuros puedan actualizar documentos antiguos in situ. Un documento cuyo `schemaVersion` sea **más nuevo** que el que entiende esta compilación se rechaza con un error — nunca se descarta en silencio ni se fusiona parcialmente; una versión demasiado antigua para migrar se rechaza igual.
+
 ## Sliding context
 
 El núcleo del harness da a cada sesión de dsh una ventana de contexto deslizante, el mismo flujo de trabajo que ofrecen Claude Code y Codex: cuando una conversación se acerca al límite de contexto del modelo (o el proveedor informa un desbordamiento), el harness **auto-compacta** — los turnos antiguos se resumen detrás de un marcador de checkpoint `compaction` que permanece visible en la transcripción, el modelo conserva solo el resumen más la cola reciente, y la sesión continúa. `/compact` dispara la misma compactación bajo demanda, y el marcador se renderiza como una fila expandible "Context compacted".

--- a/README.pt.md
+++ b/README.pt.md
@@ -165,6 +165,36 @@ Cada mensagem de usuário recém-confirmada (e cada carga de snippet) registra u
 
 `Ctrl+R` marca os resumos `[compacted] …` com um selo âmbar (o histórico permanece sem selo), snippets em verde, templates em roxo — a procedência do painel é visível de relance. Alterne com `enableCompactionHighlight`.
 
+## Exportação e importação de backup
+
+As quatro bibliotecas locais do navegador exportam e importam a partir de um único documento JSON versionado. As ações **Export JSON / Copy JSON / Import file / Paste JSON** do painel rodam totalmente no navegador: download ou cópia para a área de transferência ao exportar, seletor de arquivo ou texto colado ao importar — nada é enviado e não há RPC de host nem chamadas de rede.
+
+**Forma do documento**
+
+```json
+{
+  "schemaVersion": 1,
+  "exportedAt": 1735689600000,
+  "data": {
+    "history": ["…"],
+    "snippets": [{ "name": "…", "text": "…", "tags": [], "scope": "global", "createdAt": 0, "updatedAt": 0, "useCount": 0, "lastUsedAt": 0 }],
+    "templates": [{ "name": "…", "text": "…", "description": "", "updatedAt": 0 }],
+    "insights": [{ "text": "…", "sessions": [], "uses": 0, "lastUsedAt": 0 }]
+  }
+}
+```
+
+**Estratégia de mesclagem e conflitos**
+
+- Entradas de histórico são strings simples e deduplicam por texto exato; uma entrada duplicada ou vazia é pulada, nunca sobrescrita.
+- Snippets e templates são indexados por `name`; insights por `text` exato. Em conflito de mesma chave, a **marca de tempo mais nova vence** (`updatedAt` para snippets/templates, `lastUsedAt` para insights); uma importação mais antiga ou de marca igual é pulada, e chaves novas são anexadas.
+- A importação respeita `maxPersisted` e `maxSnippets`; templates e insights param nos limites fixos do protocolo (`500` cada).
+- O aviso de resultado informa quantos registros foram gravados e quantos foram pulados (antigos/duplicados).
+
+**Versionamento de esquema**
+
+`schemaVersion` começa em `1`. As importações rodam uma migração passo a passo (uma versão por vez) para que formatos futuros possam atualizar documentos antigos no lugar. Um documento cujo `schemaVersion` seja **mais novo** que o entendido por esta build é rejeitado com erro — nunca descartado silenciosamente nem mesclado parcialmente; uma versão antiga demais para migrar é rejeitada da mesma forma.
+
 ## Sliding context
 
 O núcleo do harness dá a cada sessão do dsh uma janela de contexto deslizante, o mesmo fluxo de trabalho do Claude Code e do Codex: quando uma conversa se aproxima do limite de contexto do modelo (ou o provedor reporta um estouro), o harness **auto-compacta** — os turnos antigos são resumidos atrás de um marcador de checkpoint `compaction` que permanece visível na transcrição, o modelo mantém apenas o resumo mais a cauda recente, e a sessão continua. `/compact` dispara a mesma compactação sob demanda, e o marcador é renderizado como uma linha expansível "Context compacted".

--- a/README.zh.md
+++ b/README.zh.md
@@ -165,6 +165,36 @@ Ctrl+R → 搜索面板在历史旁列出片段（绿色徽标 = 名称）
 
 `Ctrl+R` 给 `[compacted] …` 摘要加琥珀色徽标（历史不加徽标），片段绿色、模板紫色 —— 面板的来源一眼可见。用 `enableCompactionHighlight` 开关。
 
+## 备份导出与导入
+
+四个浏览器本地库统一导出/导入为一份带版本号的 JSON 文档。面板的 **Export JSON / Copy JSON / Import file / Paste JSON** 操作完全在浏览器内完成：导出时下载或复制到剪贴板，导入时选文件或粘贴文本——不会上传任何内容，不涉及宿主 RPC 或网络调用。
+
+**文档结构**
+
+```json
+{
+  "schemaVersion": 1,
+  "exportedAt": 1735689600000,
+  "data": {
+    "history": ["…"],
+    "snippets": [{ "name": "…", "text": "…", "tags": [], "scope": "global", "createdAt": 0, "updatedAt": 0, "useCount": 0, "lastUsedAt": 0 }],
+    "templates": [{ "name": "…", "text": "…", "description": "", "updatedAt": 0 }],
+    "insights": [{ "text": "…", "sessions": [], "uses": 0, "lastUsedAt": 0 }]
+  }
+}
+```
+
+**合并与冲突策略**
+
+- 历史条目是纯字符串，按精确文本去重；重复或空白条目被跳过，绝不覆盖。
+- 片段与模板按 `name` 为键；洞察按精确 `text` 为键。同键冲突时**最新时间戳胜出**（片段/模板看 `updatedAt`，洞察看 `lastUsedAt`）；更旧或等时间戳的导入被跳过，新键追加。
+- 导入遵守 `maxPersisted` 与 `maxSnippets`；模板与洞察止于固定协议上限（各 `500`）。
+- 结果通知会报告写入多少条、跳过多少条（更旧/重复）。
+
+**模式版本**
+
+`schemaVersion` 从 `1` 开始。导入按版本逐步迁移（一次一个版本），未来格式可就地升级旧文档。`schemaVersion` **高于**当前构建理解的文档以错误拒绝——绝不静默丢弃或部分合并；过旧无法迁移的版本同样拒绝。
+
 ## Sliding context
 
 harness 核心给每个 dsh 会话提供滑动上下文窗口 —— 与 Claude Code 和 Codex 同款的工作流：当会话接近模型的上下文上限（或提供方回报溢出）时，harness 会**自动压缩** —— 更早的轮次被总结为留在会话记录中的 `compaction` 检查点标记，模型只保留摘要加上最近的尾部，会话继续；`/compact` 可随时手动触发同样的压缩，标记在记录中渲染为可展开的"上下文已压缩"行。


### PR DESCRIPTION
zh/es/pt README drift fix: restore sections and tool parameters that lag behind the English source (verified against the five-language sync gate).